### PR TITLE
Use Vector{T} rather than Dict{R,T} for pool

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -306,25 +306,25 @@ Base.convert(::Type{Array}, pa::PooledArray{T, R, N}) where {T, R, N} = convert(
 ##############################################################################
 
 # Scalar case
-function Base.getindex(pa::PooledArray, I::Integer...)
+Base.@propagate_inbounds function Base.getindex(pa::PooledArray, I::Integer...)
     idx = pa.refs[I...]
     iszero(idx) && throw(UndefRefError())
-    return pa.pool[idx]
+    return @inbounds pa.pool[idx]
 end
 
-function Base.isassigned(pa::PooledArray, I::Int...)
+Base.@propagate_inbounds function Base.isassigned(pa::PooledArray, I::Int...)
     !iszero(pa.refs[I...])
 end
 
 # Vector case
-function Base.getindex(A::PooledArray, I::Union{Real,AbstractVector}...)
+Base.@propagate_inbounds function Base.getindex(A::PooledArray, I::Union{Real,AbstractVector}...)
     PooledArray(RefArray(getindex(A.refs, I...)), copy(A.revpool))
 end
 
 # Dispatch our implementation for these cases instead of Base
-Base.getindex(A::PooledArray, I::AbstractVector) =
+Base.@propagate_inbounds Base.getindex(A::PooledArray, I::AbstractVector) =
     PooledArray(RefArray(getindex(A.refs, I)), copy(A.revpool))
-Base.getindex(A::PooledArray, I::AbstractArray) =
+Base.@propagate_inbounds Base.getindex(A::PooledArray, I::AbstractArray) =
     PooledArray(RefArray(getindex(A.refs, I)), copy(A.revpool))
 
 ##############################################################################
@@ -357,7 +357,7 @@ function unsafe_pool_push!(pa::PooledArray{T,R}, val) where {T,R}
     pool_idx
 end
 
-function Base.setindex!(x::PooledArray, val, ind::Integer)
+Base.@propagate_inbounds function Base.setindex!(x::PooledArray, val, ind::Integer)
     x.refs[ind] = getpoolidx(x, val)
     return x
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     pc = PooledArray(c)
     @test pc == c
     @test convert(Array, pc) == c
-    #@test issorted(pc.pool)
+    #@test issorted(pc.revpool)
 
     @test copy(pc) == pc
 
@@ -23,10 +23,10 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     push!(pc, -10)
     push!(c, -10)
     @test pc == c
-    @test maximum(values(pc.pool)) == 11
-    @test maximum(keys(pc.revpool)) == 11
+    @test maximum(values(pc.revpool)) == 11
+    @test length(pc.pool) == 11
 
-    #@test issorted(pc.pool)
+    #@test issorted(pc.revpool)
 
     @test map(identity, pc) == pc
     @test map(x->2x, pc) == map(x->2x, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     pc = PooledArray(c)
     @test pc == c
     @test convert(Array, pc) == c
-    #@test issorted(pc.revpool)
+    #@test issorted(pc.invpool)
 
     @test copy(pc) == pc
 
@@ -23,10 +23,10 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     push!(pc, -10)
     push!(c, -10)
     @test pc == c
-    @test maximum(values(pc.revpool)) == 11
+    @test maximum(values(pc.invpool)) == 11
     @test length(pc.pool) == 11
 
-    #@test issorted(pc.revpool)
+    #@test issorted(pc.invpool)
 
     @test map(identity, pc) == pc
     @test map(x->2x, pc) == map(x->2x, c)


### PR DESCRIPTION
Mapping an integer to a value is much more efficient using a vector.
Also switch the pool and revpool fields since it sounds more logical.

Fixes #14.