### PR TITLE
Ensure eltype parameter is respected by constructor

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -108,11 +108,13 @@ automatically based on the number of unique elements.
 PooledArray
 
 function PooledArray{T}(d::AbstractArray, r::Type{R}) where {T,R<:Integer}
-    refs, invpool = _label(d)
+    refs, invpool = _label(d, T, R)
 
     if length(invpool) > typemax(R)
         throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
     end
+
+    PooledArray(RefArray(refs), invpool::Dict{T,R})
 end
 
 function PooledArray{T}(d::AbstractArray) where T

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -114,7 +114,8 @@ function PooledArray{T}(d::AbstractArray, r::Type{R}) where {T,R<:Integer}
         throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
     end
 
-    PooledArray(RefArray(refs), invpool::Dict{T,R})
+    # Assertions are needed since _label is not type stable
+    PooledArray(RefArray(refs::Vector{R}), invpool::Dict{T,R})
 end
 
 function PooledArray{T}(d::AbstractArray) where T

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -62,7 +62,8 @@ end
 # A no-op constructor
 PooledArray(d::PooledArray) = d
 
-function _label(xs::AbstractArray{T},
+function _label(xs::AbstractArray,
+                ::Type{T}=eltype(xs),
                 ::Type{I}=UInt8,
                 start = 1,
                 labels = Array{I}(undef, size(xs)),
@@ -105,28 +106,26 @@ automatically based on the number of unique elements.
 PooledArray
 
 function PooledArray{T}(d::AbstractArray, r::Type{R}) where {T,R<:Integer}
-    refs, pool = _label(d)
+    refs, pool = _label(d, T, R)
 
     if length(pool) > typemax(R)
         throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
     end
 
-    refs1 = convert(Vector{R}, refs)
-    pool1 = convert(Dict{T,R}, pool)
-    PooledArray(RefArray(refs1), pool1)
-end
-
-function PooledArray{T}(d::AbstractArray) where T
-    refs, pool = _label(d)
     PooledArray(RefArray(refs), pool)
 end
 
-PooledArray(d::AbstractArray{T}, r::Type{R}) where {T,R<:Integer} = PooledArray{T}(d, r)
+function PooledArray{T}(d::AbstractArray) where T
+    refs, pool = _label(d, T)
+    PooledArray(RefArray(refs), pool)
+end
+
+PooledArray(d::AbstractArray{T}, r::Type) where {T} = PooledArray{T}(d, r)
 PooledArray(d::AbstractArray{T}) where {T} = PooledArray{T}(d)
 
 # Construct an empty PooledVector of a specific type
 PooledArray(t::Type) = PooledArray(Array(t,0))
-PooledArray(t::Type, r::Type{R}) where {R<:Integer} = PooledArray(Array(t,0), r)
+PooledArray(t::Type, r::Type) = PooledArray(Array(t,0), r)
 
 ##############################################################################
 ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,4 +46,6 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     @test px2 == px[1:100]
 
     @test findall(PooledArray([true,false,true])) == [1,3]
+
+    @test PooledArray{Union{Int,Missing}}([1, 2]) isa PooledArray{Union{Int,Missing}}
 end


### PR DESCRIPTION
Also simplify code a bit by removing now redundant convert calls and unused type parameters.

Constructors taking the type `R` as an argument rather than a parameter are clearly old-school, but this can be fixed later.