### PR TITLE
avoid applying fast_sortable on integer arrays

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -428,9 +428,10 @@ function Base.vcat(a::PooledArray{T, <:Integer, 1}, b::PooledArray{S, <:Integer,
     return PooledArray(RefArray(newrefs), convert(Dict{U, refT}, newlabels))
 end
 
-fast_sortable(y::PooledArray{<:Integer}) = y
+fast_sortable(y::PooledArray) = _fast_sortable(y)
+fast_sortable(y::PooledArray{T}) where {T<:Integer} = isbitstype(T) ? y : _fast_sortable(y)
 
-function fast_sortable(y::PooledArray)
+function _fast_sortable(y::PooledArray)
     poolranks = invperm(sortperm(y.pool))
     newpool = Dict(j=>convert(eltype(y.refs), i) for (i,j) in enumerate(poolranks))
     PooledArray(RefArray(y.refs), newpool)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -428,6 +428,8 @@ function Base.vcat(a::PooledArray{T, <:Integer, 1}, b::PooledArray{S, <:Integer,
     return PooledArray(RefArray(newrefs), convert(Dict{U, refT}, newlabels))
 end
 
+fast_sortable(y::PooledArray{<:Integer}) = y
+
 function fast_sortable(y::PooledArray)
     poolranks = invperm(sortperm(y.pool))
     newpool = Dict(j=>convert(eltype(y.refs), i) for (i,j) in enumerate(poolranks))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,4 +58,20 @@ let a = rand(10), b = rand(10,10), c = rand(1:10, 1000)
     @test eltype(PooledArray(rand(300)).refs) == UInt16
     @test PooledVector == PooledArray{T, R, 1} where {T, R}
     @test PooledMatrix == PooledArray{T, R, 2} where {T, R}
+
+    v1 = PooledArray([1, 3, 2, 4])
+    v2 = PooledArray(BigInt.([1, 3, 2, 4]))
+    v3 = PooledArray(["a", "c", "b", "d"])
+
+    @test PooledArrays.fast_sortable(v1) === v1
+    @test isbitstype(eltype(PooledArrays.fast_sortable(v1)))
+    Base.Order.Perm(Base.Order.Forward, v1).data === v1
+
+    @test PooledArrays.fast_sortable(v2) == PooledArray([1, 3, 2, 4])
+    @test isbitstype(eltype(PooledArrays.fast_sortable(v2)))
+    Base.Order.Perm(Base.Order.Forward, v2).data == PooledArray([1, 3, 2, 4])
+
+    @test PooledArrays.fast_sortable(v3) == PooledArray([1, 3, 2, 4])
+    @test isbitstype(eltype(PooledArrays.fast_sortable(v3)))
+    Base.Order.Perm(Base.Order.Forward, v3).data == PooledArray([1, 3, 2, 4])
 end


### PR DESCRIPTION
The whole idea of `fast_sortable` is to return a `AbstractVector{<:Integer}` with the same sorting as the original. If the original was already of integer eltype we don't actually need to do anything.