### PR TITLE
Better support signed ref types when constructing PooledArray

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -98,6 +98,9 @@ end
 _widen(::Type{UInt8}) = UInt16
 _widen(::Type{UInt16}) = UInt32
 _widen(::Type{UInt32}) = UInt64
+_widen(::Type{Int8}) = Int16
+_widen(::Type{Int16}) = Int32
+_widen(::Type{Int32}) = Int64
 
 # Constructor from array, invpool, and ref type
 
@@ -115,12 +118,7 @@ PooledArray
 function PooledArray{T}(d::AbstractArray, r::Type{R}) where {T,R<:Integer}
     refs, invpool, pool = _label(d, T, R)
 
-    if length(invpool) > typemax(R)
-        throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
-    end
-
-    # Assertions are needed since _label is not type stable
-    PooledArray(RefArray(refs::Vector{R}), invpool::Dict{T,R}, pool)
+    PooledArray(RefArray(refs), invpool, pool)
 end
 
 function PooledArray{T}(d::AbstractArray) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,4 +94,6 @@ using DataAPI: refarray, refvalue, refpool
         @test ys === pushfirst!(ys, -100)
         @test ys == [-100, 10, 20, 30]
     end
+
+    @test eltype(PooledArray(1:300, Int8).refs) == Int16
 end


### PR DESCRIPTION
Supports https://github.com/JuliaData/Arrow.jl/issues/113. Here's a rundown of this PR:

* PoooledArrays uses UInt32 by default as the ref type
* By default, the ref type will be widened if needed, unless the user provides themselves the ref type, in which case it will be widened and constructed, then rejected afterwards for not matching the type the user provided
* With the current code, we're then left without a way to request a signed ref type unless we know exactly what type will fit all unique elements

In this PR then, I propose removing the check that the resulting ref type matches the provided ref type, and allowing widening of signed ref types. This allows, for example, passing `PooledArray(arr, Int8)` and getting a signed ref type out, only large enough to fit the input unique elements. As for removing the error path, I content that it isn't that useful; if people are passing in a type, they're almost always passing in a type wide enough anyways, and if it comes back a little wider, is that really so bad? We could perhaps change the API more dramatically and only allow passing whether the ref types should be signed or not and allow all the widening to happen automatically.

Note that users may still always pass their own `RefArray` to ensure a specific ref type, unsigned or otherwise.