### PR TITLE
Resolve aliasing problems in getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PooledArrays"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -42,11 +42,13 @@ mutable struct PooledArray{T, R<:Integer, N, RA} <: AbstractArray{T, N}
         if length(pool) != length(invpool)
             throw(ArgumentError("inconsistent pool and invpool"))
         end
-        # refs mustn't overflow pool
-        minref, maxref = extrema(rs.a)
-        # 0 indicates #undef
-        if length(rs.a) > 0 && (minref < 0 || maxref > length(invpool))
-            throw(ArgumentError("Reference array points beyond the end of the pool"))
+        if length(rs.a) > 0
+            # 0 indicates #undef
+            # refs mustn't overflow pool
+            minref, maxref = extrema(rs.a)
+            if (minref < 0 || maxref > length(invpool))
+                throw(ArgumentError("Reference array points beyond the end of the pool"))
+            end
         end
         pa = new{T,R,N,RA}(rs.a, pool, invpool, refcount)
         finalizer(x -> Threads.atomic_sub!(x.refcount, 1), pa)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -506,7 +506,7 @@ end
 
 # assume PooledArray is only used with Arrays as this is what _label does
 # this simplifies code below
-Base.IndexStyle(::Type{<:PooledArrOrSub}) = IndexLinear()
+Base.IndexStyle(::Type{<:PooledArray}) = IndexLinear()
 
 Base.@propagate_inbounds function Base.setindex!(x::PooledArray, val, ind::Int)
     x.refs[ind] = getpoolidx(x, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -426,6 +426,13 @@ end
     @test pav[1:1, [1, 2]] == [1 2]
     @test pav[[1], 1:2] == [1 2]
     @test pav[[1], [1, 2]] == [1 2]
+
+    pav2 = view(PooledArray([1]), 1)
+    pa2 = similar(pav2)
+    pa2[] = 10
+
+    @test pav2[] == 1
+    @test pa2[] == 10
 end
 
 @testset "isassigned" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ else
 end
 
 @testset "PooledArrays" begin
+    @test eltype(PooledArray(Int[])) === Int
+
     a = rand(10)
     b = rand(10,10)
     c = rand(1:10, 1000)


### PR DESCRIPTION
Life is hard. I am not sure how to write a fully generic code that would work on all supported versions of Julia and be fast.

Therefore I propose half-measure that resolves the following problem:

Timing on 1.2.0 release
```
julia> @time x = PooledArray(1:10^5);
  0.007226 seconds (59 allocations: 6.718 MiB)

julia> @time v = view(x, [1:10^5;]);
  0.000352 seconds (3 allocations: 781.375 KiB)

julia> @time s = zeros(10^5);
  0.000396 seconds (2 allocations: 781.328 KiB)

julia> @time copyto!(s, v);
  2.714555 seconds (298.98 k allocations: 7.614 MiB)
```

and this is timing with this PR:
```
julia> @time x = PooledArray(1:10^5);
  0.006874 seconds (59 allocations: 6.718 MiB)

julia> @time v = view(x, [1:10^5;]);
  0.000355 seconds (3 allocations: 781.375 KiB)

julia> @time s = zeros(10^5);
  0.000390 seconds (2 allocations: 781.328 KiB)

julia> @time copyto!(s, v);
  0.000191 seconds
```

What is the problem - we cannot use `view` for `DataAPI.refarray` in general if we want to be fast as if indices are a general `AbstractVector` then `view` must do unaliasing and this is extremely slow.

Therefore what I propose is that we use fast path for `PooledArray` or its view only if the first index in `getindex` is `AbstractVector` (it should cover 99.99% of use-cases I can think of - especially given that `PooledArray` did not work correctly for more than 1 dimension anyway in the past an no-one reported it before). In other cases we fall-back to mechanics of Julia Base that avoid allocations (and rewriting them in PooledArrays.jl would be an overkill especially that internals changed since Julia 1.0).