### PR TITLE
avoid calling f twice in map

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -325,7 +325,7 @@ function Base.map(f, x::PooledArray{T,R}) where {T,R<:Integer}
         end
         refarray = map(x->translate[x], x.refs)
     else
-        newinvpool = Dict(zip(map(f, ks), vs))
+        newinvpool = Dict(zip(ks1, vs))
         refarray = copy(x.refs)
     end
     return PooledArray(RefArray(refarray), newinvpool)


### PR DESCRIPTION
I think calling `map(f, ks)` twice is not needed, but maybe I am missing something.

@nalimilan - you were the last one to have touched this line so maybe you know the reason for the duplicate call of `map`?