### PR TITLE
add pure kwarg to map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PooledArrays"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -139,6 +139,8 @@ _widen(::Type{Int32}) = Int64
 Freshly allocate `PooledArray` using the given array as a source where each
 element will be referenced as an integer of the given type.
 
+`PooledArray` constructor is not type stable.
+
 If `reftype` is not specified, Boolean keyword arguments `signed` and `compress`
 determine the type of integer references. By default (`signed=false`), unsigned integers
 are used, as they have a greater range.

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -336,7 +336,7 @@ function _map_notpure(f, xs::PooledArray,
     for i in start:length(xs)
         vi = f(xs[i])
         Ti = typeof(vi)
-        lbl = get(invpool, x, zero(I))
+        lbl = get(invpool, vi, zero(I))
         if lbl !== zero(I)
             labels[i] = lbl
         else

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -347,7 +347,7 @@ function _map_notpure(f, xs::PooledArray, start,
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)
                 invpool2[vi] = nlabels
-                pool2 = convert(AbstractVector{T2}, pool)
+                pool2 = convert(Vector{T2}, pool)
                 push!(pool2, vi)
                 labels2 = convert(AbstractArray{I2}, labels)
                 labels2[i] = nlabels

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -304,7 +304,22 @@ Base.findall(pdv::PooledVector{Bool}) = findall(convert(Vector{Bool}, pdv))
 ##
 ##############################################################################
 
-function Base.map(f, x::PooledArray{T,R}) where {T,R<:Integer}
+"""
+    map(f, x::PooledArray; pure:Bool=false)
+        
+Transform `PooledArray` `x` by applying `f` to each element.
+
+If `pure=true` then `f` is applied to each element of pool of `x`
+exactly once (even if some elements in pool are not present it `x`).
+
+If `pure=false` (the default) `f` is applied to each element of `x`.
+"""
+function Base.map(f, x::PooledArray; pure:Bool=false)
+    pure && return _map_pure(f, x)
+    return PooledArray(collect(Base.Generator(f, x)))
+end
+
+function _map_pure(f, x::PooledArray)
     ks = collect(keys(x.invpool))
     vs = collect(values(x.invpool))
     ks1 = map(f, ks)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -341,16 +341,8 @@ function _map_notpure(f, xs::PooledArray,
             labels[i] = lbl
         else
             if nlabels == typemax(I) || !(Ti isa T)
-                if nlabels == typemax(I)
-                    I2 = _widen(I)
-                else
-                    I2 = I
-                end
-                if Ti isa T
-                    T2 = T
-                else
-                    T2 = typejoin(T, Ti)
-                end
+                I2 = nlabels == typemax(I) ? _widen(I) : I
+                T2 = Ti isa T ? T : typejoin(T, Ti)
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)
                 invpool2[vi] = nlabels

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -313,6 +313,8 @@ If `pure=true` then `f` is applied to each element of pool of `x`
 exactly once (even if some elements in pool are not present it `x`).
 This will typically be much faster when the proportion of unique values
 in `x` is small.
+
+If `pure=false` the return type of `map` is not type stable.
 """
 function Base.map(f, x::PooledArray; pure::Bool=false)
     pure && return _map_pure(f, x)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -320,7 +320,7 @@ in `x` is small.
 If `pure=false` the value returned by `map` is not type stable.
 """
 function Base.map(f, x::PooledArray{<:Any, R, N, RA}; pure::Bool=false)::Union{PooledArray{<:Any, R, N, RA},
-                                                                               PooledArray{<:Any, Int64, N,
+                                                                               PooledArray{<:Any, Int, N,
                                                                                            typeof(similar(x.refs, Int, ntuple(i -> 0, ndims(x.refs))))}} where {R, N, RA}
     pure && return _map_pure(f, x)
     length(x) == 0 && return PooledArray([f(v) for v in x])

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -313,8 +313,6 @@ If `pure=true` then `f` is applied to each element of pool of `x`
 exactly once (even if some elements in pool are not present it `x`).
 This will typically be much faster when the proportion of unique values
 in `x` is small.
-
-If `pure=false` (the default) `f` is applied to each element of `x`.
 """
 function Base.map(f, x::PooledArray; pure::Bool=false)
     pure && return _map_pure(f, x)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -333,7 +333,7 @@ end
 
 function _map_notpure(f, xs::PooledArray, start,
                       invpool::Dict{T,I}, pool::Vector{T},
-                      labels::Array{I}, nlabels::Int) where {T, I<:Integer}
+                      labels::AbstractArray{I}, nlabels::Int) where {T, I<:Integer}
     for i in start:length(xs)
         vi = f(xs[i])
         Ti = typeof(vi)
@@ -349,7 +349,7 @@ function _map_notpure(f, xs::PooledArray, start,
                 invpool2[vi] = nlabels
                 pool2 = convert(Vector{T2}, pool)
                 push!(pool2, vi)
-                labels2 = convert(Vector{I2}, labels)
+                labels2 = convert(AbstractArray{I2}, labels)
                 labels2[i] = nlabels
                 return _map_notpure(f, xs, i + 1, invpool2, pool2,
                                     labels2, nlabels)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -317,7 +317,9 @@ exactly once (even if some elements in pool are not present it `x`).
 This will typically be much faster when the proportion of unique values
 in `x` is small.
 
-If `pure=false` the value returned by `map` is not type stable.
+If `pure=false`, the returned array will use the same reference type
+as `x`, or `Int` if the number of unique values in the result is too large
+to fit in that type.
 """
 function Base.map(f, x::PooledArray{<:Any, R, N, RA}; pure::Bool=false)::Union{PooledArray{<:Any, R, N, RA},
                                                                                PooledArray{<:Any, Int, N,

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -339,14 +339,13 @@ function _map_notpure(f, xs::PooledArray, start,
                       labels::AbstractArray{I}, nlabels::Int) where {T, I<:Integer}
     for i in start:length(xs)
         vi = f(xs[i])
-        Ti = typeof(vi)
         lbl = get(invpool, vi, zero(I))
         if lbl != zero(I)
             labels[i] = lbl
         else
-            if nlabels == typemax(I) || Ti !== T
+            if nlabels == typemax(I) || !(vi isa T)
                 I2 = nlabels == typemax(I) ? Int : I
-                T2 = Ti isa T ? T : Base.promote_typejoin(T, Ti)
+                T2 = vi isa T ? T : Base.promote_typejoin(T, typeof(vi))
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)
                 invpool2[vi] = nlabels

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -305,7 +305,7 @@ Base.findall(pdv::PooledVector{Bool}) = findall(convert(Vector{Bool}, pdv))
 ##############################################################################
 
 """
-    map(f, x::PooledArray; pure:Bool=false)
+    map(f, x::PooledArray; pure::Bool=false)
         
 Transform `PooledArray` `x` by applying `f` to each element.
 
@@ -314,7 +314,7 @@ exactly once (even if some elements in pool are not present it `x`).
 
 If `pure=false` (the default) `f` is applied to each element of `x`.
 """
-function Base.map(f, x::PooledArray; pure:Bool=false)
+function Base.map(f, x::PooledArray; pure::Bool=false)
     pure && return _map_pure(f, x)
     return PooledArray(collect(Base.Generator(f, x)))
 end

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -38,6 +38,9 @@ mutable struct PooledArray{T, R<:Integer, N, RA} <: AbstractArray{T, N}
     function PooledArray{T,R,N,RA}(rs::RefArray{RA}, invpool::Dict{T, R},
                                    pool::Vector{T}=_invert(invpool),
                                    refcount::Threads.Atomic{Int}=Threads.Atomic{Int}(1)) where {T,R,N,RA<:AbstractArray{R, N}}
+        # we currently support only 1-based indexing for refs
+        Base.require_one_based_indexing(rs.a)
+
         # this is a quick but incomplete consistency check
         if length(pool) != length(invpool)
             throw(ArgumentError("inconsistent pool and invpool"))

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -319,7 +319,8 @@ in `x` is small.
 
 If `pure=false` the value returned by `map` is not type stable.
 """
-function Base.map(f, x::PooledArray; pure::Bool=false)
+function Base.map(f, x::PooledArray{<:Any, R, N, RA}; pure::Bool=false)::Union{PooledArray{<:Any, R, N, RA},
+                                                                               PooledArray{<:Any, Int64, N, Vector{Int64}}} where {R, N, RA}
     pure && return _map_pure(f, x)
     length(x) == 0 && return PooledArray([f(v) for v in x])
     v1 = f(x[1])

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -39,7 +39,15 @@ mutable struct PooledArray{T, R<:Integer, N, RA} <: AbstractArray{T, N}
                                    pool::Vector{T}=_invert(invpool),
                                    refcount::Threads.Atomic{Int}=Threads.Atomic{Int}(1)) where {T,R,N,RA<:AbstractArray{R, N}}
         # we currently support only 1-based indexing for refs
-        Base.require_one_based_indexing(rs.a)
+        if VERSION >= v"1.6"
+            Base.require_one_based_indexing(rs.a)
+        else
+            for ax in axes(re.a)
+                if first(ax) != 1
+                    throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+                end
+            end
+        end
 
         # this is a quick but incomplete consistency check
         if length(pool) != length(invpool)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -347,7 +347,7 @@ function _map_notpure(f, xs::PooledArray, start,
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)
                 invpool2[vi] = nlabels
-                pool2 = convert(Vector{T2}, pool)
+                pool2 = convert(AbstractVector{T2}, pool)
                 push!(pool2, vi)
                 labels2 = convert(AbstractArray{I2}, labels)
                 labels2[i] = nlabels

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -327,7 +327,7 @@ function Base.map(f, x::PooledArray; pure::Bool=false)
     return _map_notpure(f, x, 2, invpool, pool, labels, nlabels)
 end
 
-function _map_notpure(xs::PooledArray,
+function _map_notpure(f, xs::PooledArray,
                       start,
                       invpool::Dict{T,I},
                       pool::Vector{T},
@@ -358,7 +358,7 @@ function _map_notpure(xs::PooledArray,
                 push!(pool2, vi)
                 labels2 = convert(Vector{I2}, labels)
                 labels2[i] = nlabels
-                return _map_notpure(xs, invpool2, pool2,
+                return _map_notpure(f, xs, invpool2, pool2,
                                     labels2, i+1, nlabels)
             end
             nlabels += 1

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -320,7 +320,8 @@ in `x` is small.
 If `pure=false` the value returned by `map` is not type stable.
 """
 function Base.map(f, x::PooledArray{<:Any, R, N, RA}; pure::Bool=false)::Union{PooledArray{<:Any, R, N, RA},
-                                                                               PooledArray{<:Any, Int64, N, Vector{Int64}}} where {R, N, RA}
+                                                                               PooledArray{<:Any, Int64, N,
+                                                                                           typeof(similar(x.refs, Int, ntuple(i -> 0, ndims(x.refs))))}} where {R, N, RA}
     pure && return _map_pure(f, x)
     length(x) == 0 && return PooledArray([f(v) for v in x])
     v1 = f(x[1])
@@ -343,7 +344,7 @@ function _map_notpure(f, xs::PooledArray, start,
             labels[i] = lbl
         else
             if nlabels == typemax(I) || Ti !== T
-                I2 = nlabels == typemax(I) ? Int64 : I
+                I2 = nlabels == typemax(I) ? Int : I
                 T2 = Ti isa T ? T : Base.promote_typejoin(T, Ti)
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -131,6 +131,7 @@ _widen(::Type{UInt32}) = UInt64
 _widen(::Type{Int8}) = Int16
 _widen(::Type{Int16}) = Int32
 _widen(::Type{Int32}) = Int64
+
 # Constructor from array, invpool, and ref type
 
 """
@@ -314,7 +315,8 @@ exactly once (even if some elements in pool are not present it `x`).
 This will typically be much faster when the proportion of unique values
 in `x` is small.
 """
-function Base.map(f, x::PooledArray; pure::Bool=false)
+function Base.map(f, x::PooledArray{To, R, N}; pure::Bool=false)::Union{PooledArray{<:Any, To, N, <:Array{To, N}},
+                                                                        PooledArray{<:Any, Int64, N, <:Array{Int64, N}}} where {To, R, N}
     pure && return _map_pure(f, x)
     length(x) == 0 && return PooledArray(collect(Base.Generator(f, x)))
     v1 = f(x[1])
@@ -338,7 +340,7 @@ function _map_notpure(f, xs::PooledArray, start,
             labels[i] = lbl
         else
             if nlabels == typemax(I) || !(Ti === T)
-                I2 = nlabels == typemax(I) ? _widen(I) : I
+                I2 = nlabels == typemax(I) ? Int64 : I
                 T2 = Ti isa T ? T : Base.promote_typejoin(T, Ti)
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -39,13 +39,10 @@ mutable struct PooledArray{T, R<:Integer, N, RA} <: AbstractArray{T, N}
                                    pool::Vector{T}=_invert(invpool),
                                    refcount::Threads.Atomic{Int}=Threads.Atomic{Int}(1)) where {T,R,N,RA<:AbstractArray{R, N}}
         # we currently support only 1-based indexing for refs
-        if VERSION >= v"1.6"
-            Base.require_one_based_indexing(rs.a)
-        else
-            for ax in axes(re.a)
-                if first(ax) != 1
-                    throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
-                end
+        # TODO: change to Base.require_one_based_indexing after we drop Julia 1.0 support
+        for ax in axes(re.a)
+            if first(ax) != 1
+                throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
             end
         end
 

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -347,7 +347,7 @@ function _map_notpure(f, xs::PooledArray, start,
                 push!(pool2, vi)
                 labels2 = convert(Vector{I2}, labels)
                 labels2[i] = nlabels
-                return _map_notpure(f, xs, i+1, invpool2, pool2,
+                return _map_notpure(f, xs, i + 1, invpool2, pool2,
                                     labels2, nlabels)
             end
             nlabels += 1

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -149,7 +149,7 @@ Freshly allocate `PooledArray` using the given array as a source where each
 element will be referenced as an integer of the given type.
 
 If `reftype` is not specified then `PooledArray` constructor is not type stable.
-In this case boolean keyword arguments `signed` and `compress`
+In this case Boolean keyword arguments `signed` and `compress`
 determine the type of integer references. By default (`signed=false`), unsigned integers
 are used, as they have a greater range.
 However, the Arrow standard at https://arrow.apache.org/, as implemented in

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -319,8 +319,7 @@ in `x` is small.
 
 If `pure=false` the value returned by `map` is not type stable.
 """
-function Base.map(f, x::PooledArray{To, R, N}; pure::Bool=false)::Union{PooledArray{<:Any, To, N, <:Array{To, N}},
-                                                                        PooledArray{<:Any, Int64, N, <:Array{Int64, N}}} where {To, R, N}
+function Base.map(f, x::PooledArray; pure::Bool=false)
     pure && return _map_pure(f, x)
     length(x) == 0 && return PooledArray([f(v) for v in x])
     v1 = f(x[1])

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -327,12 +327,9 @@ function Base.map(f, x::PooledArray; pure::Bool=false)
     return _map_notpure(f, x, 2, invpool, pool, labels, nlabels)
 end
 
-function _map_notpure(f, xs::PooledArray,
-                      start,
-                      invpool::Dict{T,I},
-                      pool::Vector{T},
-                      labels::Array{I},
-                      nlabels::Int) where {T, I<:Integer}
+function _map_notpure(f, xs::PooledArray, start,
+                      invpool::Dict{T,I}, pool::Vector{T},
+                      labels::Array{I}, nlabels::Int) where {T, I<:Integer}
     for i in start:length(xs)
         vi = f(xs[i])
         Ti = typeof(vi)

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -306,7 +306,7 @@ Base.findall(pdv::PooledVector{Bool}) = findall(convert(Vector{Bool}, pdv))
 
 """
     map(f, x::PooledArray; pure::Bool=false)
-        
+
 Transform `PooledArray` `x` by applying `f` to each element.
 
 If `pure=true` then `f` is applied to each element of pool of `x`
@@ -339,7 +339,7 @@ function _map_notpure(f, xs::PooledArray, start,
         else
             if nlabels == typemax(I) || !(Ti isa T)
                 I2 = nlabels == typemax(I) ? _widen(I) : I
-                T2 = Ti isa T ? T : typejoin(T, Ti)
+                T2 = Ti isa T ? T : Base.promote_typejoin(T, Ti)
                 nlabels += 1
                 invpool2 = convert(Dict{T2, I2}, invpool)
                 invpool2[vi] = nlabels
@@ -656,14 +656,14 @@ _perm(o::F, z::V) where {F, V} = Base.Order.Perm{F, V}(o, z)
 
 Base.Order.Perm(o::Base.Order.ForwardOrdering, y::PooledArray) = _perm(o, fast_sortable(y))
 
-function Base.repeat(x::PooledArray, m::Integer...) 
+function Base.repeat(x::PooledArray, m::Integer...)
     Threads.atomic_add!(x.refcount, 1)
     PooledArray(RefArray(repeat(x.refs, m...)), x.invpool, x.pool, x.refcount)
 end
 
 function Base.repeat(x::PooledArray; inner = nothing, outer = nothing)
     Threads.atomic_add!(x.refcount, 1)
-    PooledArray(RefArray(repeat(x.refs; inner = inner, outer = outer)), 
+    PooledArray(RefArray(repeat(x.refs; inner = inner, outer = outer)),
                                 x.invpool, x.pool, x.refcount)
 end
 

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -358,8 +358,8 @@ function _map_notpure(f, xs::PooledArray,
                 push!(pool2, vi)
                 labels2 = convert(Vector{I2}, labels)
                 labels2[i] = nlabels
-                return _map_notpure(f, xs, invpool2, pool2,
-                                    labels2, i+1, nlabels)
+                return _map_notpure(f, xs, i+1, invpool2, pool2,
+                                    labels2, nlabels)
             end
             nlabels += 1
             labels[i] = nlabels

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -40,7 +40,7 @@ mutable struct PooledArray{T, R<:Integer, N, RA} <: AbstractArray{T, N}
                                    refcount::Threads.Atomic{Int}=Threads.Atomic{Int}(1)) where {T,R,N,RA<:AbstractArray{R, N}}
         # we currently support only 1-based indexing for refs
         # TODO: change to Base.require_one_based_indexing after we drop Julia 1.0 support
-        for ax in axes(re.a)
+        for ax in axes(rs.a)
             if first(ax) != 1
                 throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
             end

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -311,6 +311,8 @@ Transform `PooledArray` `x` by applying `f` to each element.
 
 If `pure=true` then `f` is applied to each element of pool of `x`
 exactly once (even if some elements in pool are not present it `x`).
+This will typically be much faster when the proportion of unique values
+in `x` is small.
 
 If `pure=false` (the default) `f` is applied to each element of `x`.
 """

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -337,7 +337,7 @@ function _map_notpure(f, xs::PooledArray, start,
         if lbl !== zero(I)
             labels[i] = lbl
         else
-            if nlabels == typemax(I) || !(Ti isa T)
+            if nlabels == typemax(I) || !(Ti === T)
                 I2 = nlabels == typemax(I) ? _widen(I) : I
                 T2 = Ti isa T ? T : Base.promote_typejoin(T, Ti)
                 nlabels += 1

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -316,7 +316,7 @@ exactly once (even if some elements in pool are not present it `x`).
 This will typically be much faster when the proportion of unique values
 in `x` is small.
 
-If `pure=false` the return type of `map` is not type stable.
+If `pure=false` the value returned by `map` is not type stable.
 """
 function Base.map(f, x::PooledArray; pure::Bool=false)
     pure && return _map_pure(f, x)

--- a/test/map_inference.jl
+++ b/test/map_inference.jl
@@ -1,0 +1,4 @@
+for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
+    x = PooledArray(fill(1, len), signed=true, compress=true);
+    @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
+end

--- a/test/map_inference.jl
+++ b/test/map_inference.jl
@@ -1,4 +1,0 @@
-for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
-    x = PooledArray(fill(1, len), signed=true, compress=true)
-    @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
-end

--- a/test/map_inference.jl
+++ b/test/map_inference.jl
@@ -1,4 +1,4 @@
 for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
-    x = PooledArray(fill(1, len), signed=true, compress=true);
+    x = PooledArray(fill(1, len), signed=true, compress=true)
     @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,6 +126,13 @@ end
     @test PooledArrays.fast_sortable(v3) == PooledArray([1, 3, 2, 4])
     @test isbitstype(eltype(PooledArrays.fast_sortable(v3)))
     Base.Order.Perm(Base.Order.Forward, v3).data == PooledArray([1, 3, 2, 4])
+
+    for T in (Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64)
+        @inferred PooledArray([1, 2, 3], T)
+    end
+    for signed in (true, false), compress in (true, false)
+        @test_throws ErrorException @inferred PooledArray([1, 2, 3])
+    end
 end
 
 @testset "pool non-copying constructor and copy tests" begin
@@ -552,4 +559,9 @@ end
     y = map(f(), x)
     @test y == fill(-1)
     @test typeof(y) === PooledArray{Int, Int8, 0, Array{Int8, 0}}
+
+    for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
+        x = PooledArray(fill(1, len), signed=true, compress=true);
+        @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -539,5 +539,5 @@ end
     x = PooledArray(fill(1, 200), signed=true, compress=true)
     y = map(f(), x)
     @test y == -1:-1:-200
-    @test typeof(y) === PooledVector{Union{Missing, Int}, Int16, Vector{Int16}}
+    @test typeof(y) === PooledVector{Int, Int16, Vector{Int16}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,5 +541,15 @@ end
     x = PooledArray(fill(1, 200), signed=true, compress=true)
     y = map(f(), x)
     @test y == -1:-1:-200
-    @test typeof(y) === PooledVector{Int, Int64, Vector{Int64}}
+    @test typeof(y) === PooledVector{Int, Int, Vector{Int}}
+
+    x = PooledArray(reshape(fill(1, 200), 2, :), signed=true, compress=true)
+    y = map(f(), x)
+    @test y == reshape(-1:-1:-200, 2, :)
+    @test typeof(y) === PooledVector{Int, Int, Matrix{Int}}
+
+    x = PooledArray(fill("a"), signed=true, compress=true)
+    y = map(f(), x)
+    @test y == fill(-1)
+    @test typeof(y) === PooledVector{Int, Int8, Array{Int8, 0}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -546,10 +546,10 @@ end
     x = PooledArray(reshape(fill(1, 200), 2, :), signed=true, compress=true)
     y = map(f(), x)
     @test y == reshape(-1:-1:-200, 2, :)
-    @test typeof(y) === PooledVector{Int, Int, Matrix{Int}}
+    @test typeof(y) === PooledMatrix{Int, Int, Matrix{Int}}
 
     x = PooledArray(fill("a"), signed=true, compress=true)
     y = map(f(), x)
     @test y == fill(-1)
-    @test typeof(y) === PooledVector{Int, Int8, Array{Int8, 0}}
+    @test typeof(y) === PooledArray{Int, Int8, 0, Array{Int8, 0}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -500,3 +500,29 @@ end
     pa2 = repeat(pa1, inner = (2, 1))
     @test pa2 == [1 2; 1 2; 3 4; 3 4]
 end
+
+@testset "map pure tests" begin
+    x = PooledArray([1, 2, 3])
+    x[3] = 1
+    y = map(-, x, pure=true)
+    @test refpool(y) = [-1, -2, -3]
+    @test y == [-1, -2, -1]
+
+    y = map(-, x)
+    @test refpool(y) = [-1, -2]
+    @test y == [-1, -2, -1]
+
+    function f()
+        i = Ref(0)
+        return x -> (i[] -= 1; i[])
+    end
+    
+    # the order is strange as we iterate invpool which is a Dict
+    y = map(f(), x, pure=true)
+    @test refpool(y) = [-3, -1, -2]
+    @test y == [-3, -1, -3]
+
+    y = map(f(), x)
+    @test refpool(y) = [-1, -2, -3]
+    @test y == [-1, -2, -3]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -518,9 +518,11 @@ end
     end
     
     # the order is strange as we iterate invpool which is a Dict
+    # and it depends on the version of Julia
     y = map(f(), x, pure=true)
-    @test refpool(y) == [-3, -1, -2]
-    @test y == [-3, -1, -3]
+    d = Dict(Set(1:3) .=> -1:-1:-3)
+    @test refpool(y) == [d[i] for i in 1:3]
+    @test y == [d[v] for v in x]
 
     y = map(f(), x)
     @test refpool(y) == [-1, -2, -3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -527,4 +527,17 @@ end
     y = map(f(), x)
     @test refpool(y) == [-1, -2, -3]
     @test y == [-1, -2, -3]
+    
+    x = PooledArray([1, missing, 2])
+    y = map(identity, x)
+    @test y == [1, missing, 2]
+    @test typeof(y) === PooledVector{Union{Missing, Int}, UInt32, Vector{UInt32}}
+    x = PooledArray([1, missing, 2], signed=true, compress=true)
+    y = map(identity, x)
+    @test y == [1, missing, 2]
+    @test typeof(y) === PooledVector{Union{Missing, Int}, Int8, Vector{Int8}}
+    x = PooledArray(fill(1, 200), signed=true, compress=true)
+    y = map(f(), x)
+    @test y == -1:-1:-200
+    @test typeof(y) === PooledVector{Union{Missing, Int}, Int16, Vector{Int16}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -562,6 +562,6 @@ end
 
     for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
         x = PooledArray(fill(1, len), signed=true, compress=true);
-        @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
+        VERSION >= v"1.6" && @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -516,7 +516,7 @@ end
         i = Ref(0)
         return x -> (i[] -= 1; i[])
     end
-    
+
     # the order is strange as we iterate invpool which is a Dict
     # and it depends on the version of Julia
     y = map(f(), x, pure=true)
@@ -527,15 +527,17 @@ end
     y = map(f(), x)
     @test refpool(y) == [-1, -2, -3]
     @test y == [-1, -2, -3]
-    
+
     x = PooledArray([1, missing, 2])
     y = map(identity, x)
-    @test y == [1, missing, 2]
+    @test isequal(y, [1, missing, 2])
     @test typeof(y) === PooledVector{Union{Missing, Int}, UInt32, Vector{UInt32}}
+
     x = PooledArray([1, missing, 2], signed=true, compress=true)
     y = map(identity, x)
-    @test y == [1, missing, 2]
+    @test isequal(y, [1, missing, 2])
     @test typeof(y) === PooledVector{Union{Missing, Int}, Int8, Vector{Int8}}
+
     x = PooledArray(fill(1, 200), signed=true, compress=true)
     y = map(f(), x)
     @test y == -1:-1:-200

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -509,7 +509,7 @@ end
     @test y == [-1, -2, -1]
 
     y = map(-, x)
-    @test refpool(y) = [-1, -2]
+    @test refpool(y) == [-1, -2]
     @test y == [-1, -2, -1]
 
     function f()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,7 +131,9 @@ end
         @inferred PooledArray([1, 2, 3], T)
     end
     for signed in (true, false), compress in (true, false)
-        @test_throws ErrorException @inferred PooledArray([1, 2, 3])
+        @test_throws ErrorException @inferred PooledArray([1, 2, 3],
+                                                          signed=signed,
+                                                          compress=compress)
     end
 end
 
@@ -560,5 +562,10 @@ end
     @test y == fill(-1)
     @test typeof(y) === PooledArray{Int, Int8, 0, Array{Int8, 0}}
 
-    VERSION >= v"1.6" && include("map_inference.jl")
+    @static if VERSION >= v"1.6"
+        for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
+            x = PooledArray(fill(1, len), signed=signed, compress=compress)
+            @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -519,10 +519,10 @@ end
     
     # the order is strange as we iterate invpool which is a Dict
     y = map(f(), x, pure=true)
-    @test refpool(y) = [-3, -1, -2]
+    @test refpool(y) == [-3, -1, -2]
     @test y == [-3, -1, -3]
 
     y = map(f(), x)
-    @test refpool(y) = [-1, -2, -3]
+    @test refpool(y) == [-1, -2, -3]
     @test y == [-1, -2, -3]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,5 +541,5 @@ end
     x = PooledArray(fill(1, 200), signed=true, compress=true)
     y = map(f(), x)
     @test y == -1:-1:-200
-    @test typeof(y) === PooledVector{Int, Int16, Vector{Int16}}
+    @test typeof(y) === PooledVector{Int, Int64, Vector{Int64}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -560,8 +560,5 @@ end
     @test y == fill(-1)
     @test typeof(y) === PooledArray{Int, Int8, 0, Array{Int8, 0}}
 
-    for signed in (true, false), compress in (true, false), len in (1, 100, 1000)
-        x = PooledArray(fill(1, len), signed=true, compress=true);
-        VERSION >= v"1.6" && @inferred PooledVector{Int, Int, Vector{Int}} map(identity, x)
-    end
+    VERSION >= v"1.6" && include("map_inference.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,7 +505,7 @@ end
     x = PooledArray([1, 2, 3])
     x[3] = 1
     y = map(-, x, pure=true)
-    @test refpool(y) = [-1, -2, -3]
+    @test refpool(y) == [-1, -2, -3]
     @test y == [-1, -2, -1]
 
     y = map(-, x)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/PooledArrays.jl/issues/63

I was thinking if it is possible to make `pure=false` branch faster, but it seems to be hard in general as we are not sure about types of values returned by `f`.