### PR TITLE
fix bug in `pop!` and `popfirst!`

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -613,14 +613,14 @@ function Base.append!(pv::PooledVector, items::AbstractArray)
     return pv
 end
 
-Base.pop!(pv::PooledVector) = pv.invpool[pop!(pv.refs)]
+Base.pop!(pv::PooledVector) = pv.pool[pop!(pv.refs)]
 
 function Base.pushfirst!(pv::PooledVector{S,R}, v::T) where {S,R,T}
     pushfirst!(pv.refs, getpoolidx(pv, v))
     return pv
 end
 
-Base.popfirst!(pv::PooledVector) = pv.invpool[popfirst!(pv.refs)]
+Base.popfirst!(pv::PooledVector) = pv.pool[popfirst!(pv.refs)]
 
 Base.empty!(pv::PooledVector) = (empty!(pv.refs); pv)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,3 +585,16 @@ end
     @test_throws BoundsError insert!(x, 9, true)
     @test x == [1, 1, 10, 99, 2, 3, 1]
 end
+
+@testset "pop! and popfirst!" begin
+    x = PooledArray([1, 2, 3])
+    @test pop!(x) == 3
+    @test x == [1, 2]
+    @test popfirst!(x) == 1
+    @test x == [2]
+    x = PooledArray(["1", "2", "3"])
+    @test pop!(x) == "3"
+    @test x == ["1", "2"]
+    @test popfirst!(x) == "1"
+    @test x == ["2"]
+end


### PR DESCRIPTION
This changes  `invpool` to `pool` in `pop!` and `popfirst!`.