### PR TITLE
Fix assertions in constructor

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -180,7 +180,7 @@ PooledArray
     end
 
     # Assertions are needed since _label is not type stable
-    return PooledArray(RefArray(refs::Array{ndims(d), R}), invpool::Dict{T,R}, pool)
+    return PooledArray(RefArray(refs::Array{R, ndims(d)}), invpool::Dict{T,R}, pool)
 end
 
 @inline function PooledArray{T}(d::AbstractArray; signed::Bool=false, compress::Bool=false) where {T}

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -179,7 +179,8 @@ PooledArray
         throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
     end
 
-    return PooledArray(RefArray(refs), invpool, pool)
+    # Assertions are needed since _label is not type stable
+    return PooledArray(RefArray(refs::Array{ndims(d), R}), invpool::Dict{T,R}, pool)
 end
 
 @inline function PooledArray{T}(d::AbstractArray; signed::Bool=false, compress::Bool=false) where {T}

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -179,8 +179,7 @@ PooledArray
         throw(ArgumentError("Cannot construct a PooledArray with type $R with a pool of size $(length(pool))"))
     end
 
-    # Assertions are needed since _label is not type stable
-    return PooledArray(RefArray(refs::Vector{R}), invpool::Dict{T,R}, pool)
+    return PooledArray(RefArray(refs), invpool, pool)
 end
 
 @inline function PooledArray{T}(d::AbstractArray; signed::Bool=false, compress::Bool=false) where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -587,5 +587,5 @@ end
 end
 
 @testset "constructor with reftype" begin
-    @test typeof(PooledAray([1 2; 3 4], Int8)) === PooledMatrix{Int, Int8, Matrix{Int8}}
+    @test typeof(PooledArray([1 2; 3 4], Int8)) === PooledMatrix{Int, Int8, Matrix{Int8}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,3 +585,7 @@ end
     @test_throws BoundsError insert!(x, 9, true)
     @test x == [1, 1, 10, 99, 2, 3, 1]
 end
+
+@testset "constructor with reftype" begin
+    @test typeof(PooledAray([1 2; 3 4], Int8) === PooledMatrix{Int, Int8, Matrix{Int8}}
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -587,5 +587,5 @@ end
 end
 
 @testset "constructor with reftype" begin
-    @test typeof(PooledAray([1 2; 3 4], Int8) === PooledMatrix{Int, Int8, Matrix{Int8}}
+    @test typeof(PooledAray([1 2; 3 4], Int8)) === PooledMatrix{Int, Int8, Matrix{Int8}}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,10 @@ end
 
     for T in (Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64)
         @inferred PooledArray([1, 2, 3], T)
+        @inferred PooledArray([1 2 3], T)
     end
+    @test typeof(PooledArray([1 2; 3 4], Int8)) === PooledMatrix{Int, Int8, Matrix{Int8}}
+
     for signed in (true, false), compress in (true, false)
         @test_throws ErrorException @inferred PooledArray([1, 2, 3],
                                                           signed=signed,
@@ -584,8 +587,4 @@ end
     @test insert!(x, 7, true) == [1, 1, 10, 99, 2, 3, 1]
     @test_throws BoundsError insert!(x, 9, true)
     @test x == [1, 1, 10, 99, 2, 3, 1]
-end
-
-@testset "constructor with reftype" begin
-    @test typeof(PooledArray([1 2; 3 4], Int8)) === PooledMatrix{Int, Int8, Matrix{Int8}}
 end


### PR DESCRIPTION
@nalimilan I propose to revert https://github.com/JuliaData/PooledArrays.jl/commit/b3036f8a19a150829cf6b770b5ddab881239ce45 you have made. I do not understand why it is needed and currently it leads to an incorrect result:
```
julia> PooledArray([1 2; 3 4], Int8)
ERROR: TypeError: in typeassert, expected Vector{Int8}, got a value of type Matrix{Int8}
```