### PR TITLE
Fix copyto! with #undef

### DIFF
--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -279,7 +279,11 @@ function Base.copyto!(dest::PooledArrOrSub{T, N, R}, doffs::Union{Signed, Unsign
         copyto!(DataAPI.refarray(dest), doffs, DataAPI.refarray(src), soffs, n)
     else
         @inbounds for i in 0:n-1
-            dest[doffs+i] = src[soffs+i]
+            if iszero(src[soffs+i])
+                dest.refs[doffs+i] = zero(eltype(dest.refs))
+            else
+                dest[doffs+i] = src[soffs+i]
+            end
         end
     end
     return dest


### PR DESCRIPTION
This fixes the following problem:
```
julia> x = PooledArray(["a", "b"])
2-element PooledVector{String, UInt32, Vector{UInt32}}:
 "a"
 "b"

julia> y = resize!(PooledArray(String[]), 2)
2-element PooledVector{String, UInt32, Vector{UInt32}}:
 #undef
 #undef

julia> copyto!(x, y)
ERROR: UndefRefError: access to undefined reference
```

Then maybe we also need to add in this PR
```
Base.copyto!(dest::PooledArrOrSub{T, N, R}, doffs::Union{Signed, Unsigned},
                      src::AbstractArray, soffs::Union{Signed, Unsigned},
                      n::Union{Signed, Unsigned}) where {T, N, R}
```
method depending on how https://github.com/JuliaLang/julia/issues/45125 is resolved.

CC @nalimilan 