### PR TITLE
optimize permute! and invpermute!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [targets]
-test = ["OffsetArrays", "Test"]
+test = ["OffsetArrays", "Random", "Test"]

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -297,6 +297,16 @@ function Base.reverse(x::PooledArray)
     PooledArray(RefArray(reverse(x.refs)), x.invpool, x.pool, x.refcount)
 end
 
+function Base.permute!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
+    permute!(x.refs, p)
+    return x
+end
+
+function Base.invpermute!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
+    invpermute!(x.refs, p)
+    return x
+end
+
 function Base.permute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
     Base.permute!!(x.refs, p)
     return x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Test, OffsetArrays
 using PooledArrays
 using DataAPI: refarray, refvalue, refpool, invrefpool
 using PooledArrays: refcount
+using Random: randperm
+
 import Future.copy!
 
 if Threads.nthreads() < 2
@@ -34,6 +36,17 @@ end
 
     @test sort(pc) == sort(c)
     @test sortperm(pc) == sortperm(c)
+
+    perm = randperm(length(pc))
+    pc2 = copy(pc)
+    pc3 = permute!(pc2, perm)
+    @test pc2 === pc3
+    @test pc2 == pc[perm]
+
+    pc2 = copy(pc)
+    pc3 = invpermute!(pc2, perm)
+    @test pc2 === pc3
+    @test pc2[perm] == pc
 
     push!(pc, -10)
     push!(c, -10)


### PR DESCRIPTION
After https://github.com/JuliaLang/julia/pull/44941 `permute!` and `invpermute!` no longer call the `Base.permute!!` and `Base.invpermute!!` methods. This ensures that `permute!` and `invpermute!` stay optimized for `PooledArray`s, otherwise they get a suboptimal fallback (see benchmark below).

```julia
julia> using BenchmarkTools, PooledArrays, Random

julia> perm = randperm(10_000);

julia> @btime permute!($v, $perm) setup=(v=PooledArray(rand(1:1000, 10_000)));
  9.800 μs (2 allocations: 39.11 KiB)

julia> @btime ($v .= $v[$perm]) setup=(v=PooledArray(rand(1:1000, 10_000))); # current permute! fallback
  10.800 μs (4 allocations: 39.17 KiB)

julia> @btime invpermute!($v, $perm) setup=(v=PooledArray(rand(1:1000, 10_000)));
  11.900 μs (2 allocations: 39.11 KiB)

julia> @btime ($v[$perm] = $v) setup=(v=PooledArray(rand(1:1000, 10_000))); # current invpermute! fallback
  103.400 μs (4 allocations: 39.17 KiB)
```

The improvement is much more substantial for `invpermute!`, but I imagine it makes sense to have both methods fully optimized. I was actually surprised that the `permute!` fallback was already almost optimal. EDIT: that was just due to it calling the optimized `getindex(v::PooledArray, i::AbstractVector)` and `copyto!(dst::PooledArray, src::PooledArray)` methods, whereas `invpermute!` has to call `setindex!`, which is more costly.