### PR TITLE
Remove usage of Base internals (permute!!)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PooledArrays"
 uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -307,20 +307,6 @@ function Base.invpermute!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
     return x
 end
 
-if isdefined(Base, :permute!!)
-    function Base.permute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
-        Base.permute!!(x.refs, p)
-        return x
-    end
-end
-
-if isdefined(Base, :invpermute!!)
-    function Base.invpermute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
-        Base.invpermute!!(x.refs, p)
-        return x
-    end
-end
-
 Base.similar(pa::PooledArray{T,R}, S::Type, dims::Dims) where {T,R} =
     PooledArray(RefArray(zeros(R, dims)), Dict{S,R}())
 

--- a/src/PooledArrays.jl
+++ b/src/PooledArrays.jl
@@ -307,14 +307,18 @@ function Base.invpermute!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
     return x
 end
 
-function Base.permute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
-    Base.permute!!(x.refs, p)
-    return x
+if isdefined(Base, :permute!!)
+    function Base.permute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
+        Base.permute!!(x.refs, p)
+        return x
+    end
 end
 
-function Base.invpermute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
-    Base.invpermute!!(x.refs, p)
-    return x
+if isdefined(Base, :invpermute!!)
+    function Base.invpermute!!(x::PooledArray, p::AbstractVector{T}) where T<:Integer
+        Base.invpermute!!(x.refs, p)
+        return x
+    end
 end
 
 Base.similar(pa::PooledArray{T,R}, S::Type, dims::Dims) where {T,R} =


### PR DESCRIPTION
`permute!!` and `invpermute!!` are internal functions of Base and are likely to be [removed](https://github.com/JuliaLang/julia/issues/44869) soon. This PR makes it so that if they are gone, PooledArrays will still compile.

AFAICT, nobody uses these methods anyway, so deleting them would work too, but this approach has a more minimal impact.